### PR TITLE
fix: http302 function ARN output

### DIFF
--- a/edge/nodejs/http302-from-origin/template.yaml
+++ b/edge/nodejs/http302-from-origin/template.yaml
@@ -59,7 +59,7 @@ Resources:
 Outputs:
   Http302Function:
     Description: "Lambda Edge function ARN"
-    Value: "Http302Function"
+    Value: !GetAtt Http302Function.Arn
   Http302FunctionIamRole:
     Description: "Implicit IAM Role created for Simple Lambda Edge function"
     Value: !GetAtt EdgeFunctionRole.Arn


### PR DESCRIPTION
*Issue #, if available:*
#102 

*Description of changes:*
get real http302 function ARN

*How Has This Been Tested:*

```
sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
```
after deploying and get right http302 function ARN

*[V] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

