### PR TITLE
fix: remove explicit role name of 'add-security-headers'

### DIFF
--- a/edge/nodejs/add-security-headers/template.yaml
+++ b/edge/nodejs/add-security-headers/template.yaml
@@ -23,8 +23,8 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['gcr','gcr-solutions','cloudfront','cloudfront+','aws-cloudfront-extensions','edge','lambda-edge', 'aws']
     HomePageUrl: https://www.amazonaws.cn/en/solutions/lambda-edge-collection-for-cloudfront/
-    SemanticVersion: 1.0.0
-    SourceCodeUrl: https://github.com/cc4i/aws-cloudfront-extensions/edge/nodejs/add-security-headers
+    SemanticVersion: 1.0.1
+    SourceCodeUrl: https://github.com/awslabs/aws-cloudfront-extensions/tree/main/edge/nodejs/add-security-headers
 
 
 
@@ -42,7 +42,6 @@ Resources:
   EdgeFunctionRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: !Sub ${AWS::StackName}-edgeFunction
         AssumeRolePolicyDocument:
           Version: 2012-10-17
           Statement:


### PR DESCRIPTION
the role name is created by cfn


*Issue #, if available:*

closes #130

*Description of changes:*

*How Has This Been Tested:*

* [x] My testing has passed *

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

