### PR TITLE
fix: add WAFScope check and glue table schema for alb

### DIFF
--- a/templates/aws-cloudfront-waf/lib/aws-cloudfront-waf-main.ts
+++ b/templates/aws-cloudfront-waf/lib/aws-cloudfront-waf-main.ts
@@ -1245,7 +1245,7 @@ export class AwsCloudfrontWafStack extends cdk.Stack {
     } else {
       const glueAppAccessLogsTable = new glue.CfnTable(this, 'glueAppAccessLogsTable', {
         databaseName: glueAccessLogsDatabase.databaseName,
-        catalogId: cdk.Aws.ACCOUNT_ID,
+        catalogId: this.account,
         tableInput: {
           name: 'app_access_logs',
           description: this.stackName + ' - APP Access Logs',


### PR DESCRIPTION
*Issue #, if available:*  fixed https://github.com/awslabs/aws-cloudfront-extensions/issues/164

*Description of changes:*  WAFScope check and modify something for ALB access log, such as glue table schema 

*How Has This Been Tested:* Issue https://github.com/awslabs/aws-cloudfront-extensions/issues/164 has description.

*[x] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

