### PR TITLE
Add relative-redirect-based-on-country CloudFront Function

### DIFF
--- a/function/js/redirect-based-on-country/README.md
+++ b/function/js/redirect-based-on-country/README.md
@@ -1,12 +1,23 @@
 # URL redirects to the county-specific version of a site
 
-**CloudFront Functions event type: viewer request**
-
-This function redirects a user to a country-specific version of a site based on the country of the user. For example, if the user is in Germany, the function redirects the user to the `/de/index.html` page which is the Germany-specific version of the site. If the user is not in Germany, the request passes through with no modification to the URL.
-
 This function makes use of the `Cloudfront-Viewer-Country` [geo-location header](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html#cloudfront-headers-viewer-location) which performs a lookup on the request to determine the user's country and includes that value in the `Cloudfront-Viewer-Country` request header. You can use any of the geo-location or [device detection](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html#cloudfront-headers-device-type) headers that are available from CloudFront. For the geo-location or device detection headers to appear in the request object within a function, you must allow these headers (or allow all viewer headers) in a CloudFront [origin request policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-understand-origin-request-policy) or [cache policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-understand-cache-policy).
+
+## CloudFront Functions event type
+
+**viewer-request**
+
+## redirect-based-on-country
+
+This function redirects a user to a country-specific version of a site based on the country of the user.
+For example, if the user is in Germany, the function redirects the user to the `/de/index.html` page which is the Germany-specific version of the site. If the user is not in Germany, the request passes through with no modification to the URL.
+This functions is building the whole URL(`https://host/de/index.html`) to redirect.
+
+## relative-redirect-based-on-country
+
+This function redirects a user to a country-specific version of a site based on the country of the user.
+For example, if the user is in Germany, the function redirects the user to the `/de/` page which is the German version of the site. If the user is not in Germany or Poland, the function redirects the user to the `/en/` page which is the English version of the site.
+This functions use only relative path(`/en/`) to redirect.
 
 ## Deployment
 
 To deploy the stack, go to [CloudFront Extensions Workshop](https://awslabs.github.io/aws-cloudfront-extensions/#cloudfront-function), find the CloudFront Function and click **Deploy** button.
-

--- a/function/js/redirect-based-on-country/relative-redirect-based-on-country.yaml
+++ b/function/js/redirect-based-on-country/relative-redirect-based-on-country.yaml
@@ -1,0 +1,37 @@
+Description: (SO8145) relative-redirect-based-on-country is a CloudFront Function which redirects a user to a country-specific version of a site based on the country of the user
+
+Resources:
+  RedirectFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: relative-redirect-based-on-country
+      AutoPublish: true
+      FunctionConfig:
+        Comment: relative-redirect-based-on-country
+        Runtime: cloudfront-js-1.0
+      FunctionCode: |
+        function handler(event) {
+            var redirects = {
+                'DE': '/de/',
+                'PL': '/pl/'
+            };
+            var headers = event.request.headers;
+            var newPath = '/en/';
+
+            var country = headers['cloudfront-viewer-country'].value;
+            if (country in redirects) {
+                newPath = redirects[country];
+            }
+
+            return {
+                statusCode: 307,
+                statusDescription: 'Temporary Redirect',
+                headers: {"location": {"value": newPath}}
+            };
+        }
+
+
+Outputs:
+  SolutionId:
+    Description: "Solution id"
+    Value: "SO8145"


### PR DESCRIPTION
*Issue #, if available:*
No issue.

*Description of changes:*
New template added to **function/js/redirect-based-on-country**.
This function uses a relative path to redirect based on country.

After the merge, you can add this template to [https://awslabs.github.io/aws-cloudfront-extensions/]( https://awslabs.github.io/aws-cloudfront-extensions/).

*How Has This Been Tested:*
I deployed it as my own stack with CloudFront.

*[x] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

