### PR TITLE
[Fix] When Pop is not functional, the dig command to get the pop ip address will fail, update the exception to make it more readable

### DIFF
--- a/edge/cdk/deployment/build-s3-dist.sh
+++ b/edge/cdk/deployment/build-s3-dist.sh
@@ -109,6 +109,7 @@ npm run synth -- --app "npx ts-node --prefer-ts-exts ${SRC_PATH}/prewarm/prewarm
 npm run synth -- --app "npx ts-node --prefer-ts-exts ${SRC_PATH}/true-client-ip/true-client-ip.ts" --output ${CDK_OUT_PATH}
 npm run synth -- --app "npx ts-node --prefer-ts-exts ${SRC_PATH}/redirect-by-country/redirect-by-country.ts" --output ${CDK_OUT_PATH}
 npm run synth -- --app "npx ts-node --prefer-ts-exts ${SRC_PATH}/resize-image/resize-image.ts" --output ${CDK_OUT_PATH}
+npm run synth -- --app "npx ts-node --prefer-ts-exts ${SRC_PATH}/redirect-by-device/redirect-by-device.ts" --output ${CDK_OUT_PATH}
 
 ls ${GLOBAL_S3_ASSETS_PATH}
 ls ${GLOBAL_S3_ASSETS_PATH}/${prefixes[0]}

--- a/edge/cdk/extensions/prewarm/lambda/agent/agent.py
+++ b/edge/cdk/extensions/prewarm/lambda/agent/agent.py
@@ -85,7 +85,10 @@ def download_file_with_curl(url, cf_domain, original_url):
     pop_domain = urlparse(url).netloc
     popList = pydig.query(pop_domain, 'A')
     print(popList)
-    popAddress = popList[0]
+    try:
+        popAddress = popList[0]
+    except Exception as e:
+        raise Exception(f'Failed to find the popAddress ipaddress with pop_domain: {pop_domain}') 
 
     # Get the original url domain name
     parsed_url = urlparse(original_url)


### PR DESCRIPTION
When Pop is not functional, the dig command to get the pop ip address will fail, update the exception to make it more readable

*Description of changes:*

*How Has This Been Tested:*
 Tested in dev account

*[x] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

