### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-apps.yaml
+++ b/.github/workflows/release-apps.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: read input tag
       id: read_tag
       run: |
-        echo "::set-output name=tag_value::`./scripts/read-input-tag.sh`"
+        echo "tag_value=`./scripts/read-input-tag.sh`" >> "$GITHUB_OUTPUT"
     - name: check tag existing 
       uses: mukunku/tag-exists-action@v1.0.0
       id: checkTag


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter