### PR TITLE
Setting MemorySize to 512

### DIFF
--- a/edge/nodejs/resize-picture/template.yaml
+++ b/edge/nodejs/resize-picture/template.yaml
@@ -71,6 +71,7 @@ Resources:
       Handler: index.handler
       Runtime: python3.10
       Timeout: 180
+      MemorySize: 512
       Policies:
         - Statement:
           - Sid: ResizePolicy 


### PR DESCRIPTION
To complete the custom resource, the Lambda function requires more than default 128mb of memory to complete execution. This pull request intends to set the memory to 512mb.

*Issue #, if available:* https://github.com/awslabs/aws-cloudfront-extensions/issues/433

*Description of changes:* Setting the Lambda function's memory to 512mb.

*How Has This Been Tested:* Deployed the template locally to confirm validation.

*[x] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

